### PR TITLE
fix: disable Contextmenu & fix Addon Icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>NoRiskClient Launcher</title>
 </head>
 
-<body>
+<body oncontextmenu="return false">
     <div id="app"></div>
     <script type="module" src="src/main.js"></script>
 </body>

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,6 +8,7 @@
      * a value or a type, so tell TypeScript to enforce using
      * `import type` instead of `import` for Types.
      */
+    "ignoreDeprecations": "5.0",
     "importsNotUsedAsValues": "error",
     "isolatedModules": true,
     "resolveJsonModule": true,

--- a/src/components/addons/datapacks/DatapackItem.svelte
+++ b/src/components/addons/datapacks/DatapackItem.svelte
@@ -95,7 +95,6 @@
         margin-bottom: 10px;
         gap: 1em;
         margin-top: 0.3em;
-        cursor: pointer;
     }
 
     .blacklisted {

--- a/src/components/addons/datapacks/DatapackItem.svelte
+++ b/src/components/addons/datapacks/DatapackItem.svelte
@@ -12,7 +12,9 @@
     <div class="image-text-wrapper">
         <!-- svelte-ignore a11y-img-redundant-alt -->
         {#if type != 'CUSTOM'}
-            <img class="icon" src={datapack.icon_url} alt="Shader Icon">
+            <div class="icon-fallback">
+                <img class="icon" src={datapack.icon_url} alt=" " onerror="this.style.display='none'">
+            </div>
         {:else}
             <div class="custom-datapack-icon">🛠️</div>
         {/if}
@@ -152,6 +154,15 @@
         object-fit: contain;
         background: var(--background-contrast-color);
         box-shadow: 3px 3px 1px rgba(0, 0, 0, 0.5);
+    }
+
+    .icon-fallback {
+    background-image: url("https://docs.modrinth.com/img/logo.svg");
+    min-width: 90px; 
+    min-height: 90px;
+    background-position: center center;
+    background-size: 90%;
+    background-repeat: no-repeat;
     }
 
     .datapack-title {

--- a/src/components/addons/datapacks/DatapackItem.svelte
+++ b/src/components/addons/datapacks/DatapackItem.svelte
@@ -150,6 +150,7 @@
     .icon {
         width: 90px;
         height: 90px;
+        object-fit: contain;
         background: var(--background-contrast-color);
         box-shadow: 3px 3px 1px rgba(0, 0, 0, 0.5);
     }

--- a/src/components/addons/mods/ModItem.svelte
+++ b/src/components/addons/mods/ModItem.svelte
@@ -208,6 +208,7 @@
     .icon {
         width: 90px;
         height: 90px;
+        object-fit: contain;
         background: var(--background-contrast-color);
         box-shadow: 3px 3px 1px rgba(0, 0, 0, 0.5);
     }

--- a/src/components/addons/mods/ModItem.svelte
+++ b/src/components/addons/mods/ModItem.svelte
@@ -145,7 +145,6 @@
         margin-bottom: 10px;
         gap: 1em;
         margin-top: 0.3em;
-        cursor: pointer;
     }
 
     .blacklisted {

--- a/src/components/addons/mods/ModItem.svelte
+++ b/src/components/addons/mods/ModItem.svelte
@@ -13,7 +13,9 @@
     <div class="image-text-wrapper">
         <!-- svelte-ignore a11y-img-redundant-alt -->
         {#if type != 'CUSTOM'}
-            <img class="icon" src={mod.icon_url ?? mod.image_url} alt="Mod Icon">
+            <div class="icon-fallback">
+                <img class="icon" src={mod.icon_url ?? mod.image_url} alt=" " onerror="this.style.display='none'">
+            </div>
         {:else}
             <div class="custom-mod-icon">📦</div>
         {/if}
@@ -210,6 +212,15 @@
         object-fit: contain;
         background: var(--background-contrast-color);
         box-shadow: 3px 3px 1px rgba(0, 0, 0, 0.5);
+    }
+
+    .icon-fallback {
+    background-image: url("https://docs.modrinth.com/img/logo.svg");
+    min-width: 90px; 
+    min-height: 90px;
+    background-position: center center;
+    background-size: 90%;
+    background-repeat: no-repeat;
     }
 
     .mod-title {

--- a/src/components/addons/resourcepacks/ResourcePackItem.svelte
+++ b/src/components/addons/resourcepacks/ResourcePackItem.svelte
@@ -12,7 +12,9 @@
     <div class="image-text-wrapper">
         <!-- svelte-ignore a11y-img-redundant-alt -->
         {#if type != 'CUSTOM'}
-            <img class="icon" src={resourcePack.icon_url} alt="Shader Icon">
+            <div class="icon-fallback">
+                <img class="icon" src={resourcePack.icon_url} alt=" " onerror="this.style.display='none'">
+            </div>
         {:else}
             <div class="custom-resourcepack-icon">🎨</div>
         {/if}
@@ -152,6 +154,15 @@
         object-fit: contain;
         background: var(--background-contrast-color);
         box-shadow: 3px 3px 1px rgba(0, 0, 0, 0.5);
+    }
+
+    .icon-fallback {
+    background-image: url("https://docs.modrinth.com/img/logo.svg");
+    min-width: 90px; 
+    min-height: 90px;
+    background-position: center center;
+    background-size: 90%;
+    background-repeat: no-repeat;
     }
 
     .resourcepack-title {

--- a/src/components/addons/resourcepacks/ResourcePackItem.svelte
+++ b/src/components/addons/resourcepacks/ResourcePackItem.svelte
@@ -95,7 +95,6 @@
         margin-bottom: 10px;
         gap: 1em;
         margin-top: 0.3em;
-        cursor: pointer;
     }
     
     .blacklisted {

--- a/src/components/addons/resourcepacks/ResourcePackItem.svelte
+++ b/src/components/addons/resourcepacks/ResourcePackItem.svelte
@@ -150,6 +150,7 @@
     .icon {
         width: 90px;
         height: 90px;
+        object-fit: contain;
         background: var(--background-contrast-color);
         box-shadow: 3px 3px 1px rgba(0, 0, 0, 0.5);
     }

--- a/src/components/addons/shaders/ShaderItem.svelte
+++ b/src/components/addons/shaders/ShaderItem.svelte
@@ -12,7 +12,9 @@
     <div class="image-text-wrapper">
         <!-- svelte-ignore a11y-img-redundant-alt -->
         {#if type != 'CUSTOM'}
-            <img class="icon" src={shader.icon_url} alt="Shader Icon">
+            <div class="icon-fallback">
+                <img class="icon" src={shader.icon_url} alt=" " onerror="this.style.display='none'">
+            </div>
         {:else}
             <div class="custom-shader-icon">🔮</div>
         {/if}
@@ -152,6 +154,15 @@
         object-fit: contain;
         background: var(--background-contrast-color);
         box-shadow: 3px 3px 1px rgba(0, 0, 0, 0.5);
+    }
+
+    .icon-fallback {
+    background-image: url("https://docs.modrinth.com/img/logo.svg");
+    min-width: 90px; 
+    min-height: 90px;
+    background-position: center center;
+    background-size: 90%;
+    background-repeat: no-repeat;
     }
 
     .shader-title {

--- a/src/components/addons/shaders/ShaderItem.svelte
+++ b/src/components/addons/shaders/ShaderItem.svelte
@@ -95,7 +95,6 @@
         margin-bottom: 10px;
         gap: 1em;
         margin-top: 0.3em;
-        cursor: pointer;
     }
 
     .blacklisted {

--- a/src/components/addons/shaders/ShaderItem.svelte
+++ b/src/components/addons/shaders/ShaderItem.svelte
@@ -150,6 +150,7 @@
     .icon {
         width: 90px;
         height: 90px;
+        object-fit: contain;
         background: var(--background-contrast-color);
         box-shadow: 3px 3px 1px rgba(0, 0, 0, 0.5);
     }

--- a/src/components/home/HomeScreen.svelte
+++ b/src/components/home/HomeScreen.svelte
@@ -53,6 +53,6 @@
   }
   
   @keyframes effect {
-   100% {-webkit-mask-position:left} /* transformation, 50 to swipe left->right->left; 100 to swipe left->right. 50 needs double effect duration */
+    100% {-webkit-mask-position:left}
   }
 </style>

--- a/src/components/home/widgets/HomeLeftNavbar.svelte
+++ b/src/components/home/widgets/HomeLeftNavbar.svelte
@@ -132,6 +132,6 @@
   .home-navbar-wrapper h1:hover {
     color: var(--hover-color);
     text-shadow: 1px 1px var(--hover-color-text-shadow);
-    transform: scale(1.2) translateX(12.5px);
+    transform: scale(1.2) translateX(12.5px) perspective(1px);
   }
 </style>

--- a/src/components/home/widgets/HomeNavbar.svelte
+++ b/src/components/home/widgets/HomeNavbar.svelte
@@ -169,13 +169,13 @@
   .home-navbar-wrapper h1:hover {
     color: var(--hover-color);
     text-shadow: 1px 1px var(--hover-color-text-shadow);
-    transform: scale(1.2) translateX(-10px);
+    transform: scale(1.2) translateX(-10px) perspective(1px);
   }
 
   .home-navbar-wrapper h1.quit:hover {
     color: red;
     text-shadow: 1px 1px #460000;
-    transform: scale(1.2);
+    transform: scale(1.2) perspective(1px);
   }
 
   .home-navbar-wrapper h1.invite-button {


### PR DESCRIPTION
## DONE:
- Globally Disable Contextmenu (rightclick-menu).
- Fix [Addon Icons](https://discord.com/channels/774271756549619722/1274042291811651685) (stretching, missing image)
- Fix [Launcher Bug](https://discord.com/channels/774271756549619722/1271541212351823934) (deine Popups sind schuld)
- Fix [Error Messages](https://discord.com/channels/774271756549619722/1272846575085031515) (related zum Launcher Bug)


## TODO:
- Fix HomeNavbar Textcolor Change on HomeLeftNavbar hover (leftover, low prio)